### PR TITLE
[Feature] Add support for non-authenticated logs

### DIFF
--- a/src/app/Models/Activity.php
+++ b/src/app/Models/Activity.php
@@ -24,9 +24,9 @@ class Activity extends ModelsActivity
 
     public function getUser()
     {
-        $name = $this->causer->name;
-        $email = $this->causer->email;
+        $name = $this->causer->name ?? '';
+        $email = $this->causer->email ?? '';
 
-        return $name."($email)";
+        return $name . $email ? " ($email)" : "";
     }
 }


### PR DESCRIPTION
`spatie/laravel-activitylog` supports logging stuff without user information:
- the db column names are nullable
- their API works whether a user is authenticated or not

Since the original package supports that, I think the interface should support it too.
That's what this PR does. 

PS. Plus, it adds a space between the name and parentheses. 😅 I know, OCD much...